### PR TITLE
Allow cross origin when requesting to the hornet API

### DIFF
--- a/iota-hornet/docker-compose.yml
+++ b/iota-hornet/docker-compose.yml
@@ -33,12 +33,14 @@ services:
       - "traefik.http.services.hornet.loadbalancer.healthCheck.interval=15s"
       - "traefik.http.services.hornet.loadbalancer.healthCheck.timeout=5s"
 
-      - "traefik.http.routers.hornet.middlewares=redirect-dashboard"
+      - "traefik.http.routers.hornet.middlewares=security-headers,redirect-dashboard"
 
       # middlewares
       - "traefik.http.middlewares.redirect-dashboard.redirectregex.regex=^(https?://[^/]+)/?$$"
       - "traefik.http.middlewares.redirect-dashboard.redirectregex.replacement=$$1/dashboard/"
       - "traefik.http.middlewares.redirect-dashboard.redirectregex.permanent=true"
+      - "traefik.http.middlewares.security-headers.headers.frameDeny=true"
+      - "traefik.http.middlewares.security-headers.headers.contentTypeNosniff=true"
       
     cap_drop:
       - ALL

--- a/iota-hornet/docker-compose.yml
+++ b/iota-hornet/docker-compose.yml
@@ -33,19 +33,13 @@ services:
       - "traefik.http.services.hornet.loadbalancer.healthCheck.interval=15s"
       - "traefik.http.services.hornet.loadbalancer.healthCheck.timeout=5s"
 
-      - "traefik.http.routers.hornet.middlewares=security-headers,redirect-dashboard"
+      - "traefik.http.routers.hornet.middlewares=redirect-dashboard"
 
       # middlewares
       - "traefik.http.middlewares.redirect-dashboard.redirectregex.regex=^(https?://[^/]+)/?$$"
       - "traefik.http.middlewares.redirect-dashboard.redirectregex.replacement=$$1/dashboard/"
       - "traefik.http.middlewares.redirect-dashboard.redirectregex.permanent=true"
-
-      - "traefik.http.middlewares.security-headers.headers.accesscontrolallowmethods=GET,POST,PUT,DELETE,OPTIONS"
-      - "traefik.http.middlewares.security-headers.headers.customResponseHeaders.Access-Control-Allow-Origin=https://${HORNET_HOST:?WASP_HOST is missing}:${HORNET_HTTPS_PORT:-443}"
-      - "traefik.http.middlewares.security-headers.headers.accesscontrolmaxage=100"
-      - "traefik.http.middlewares.security-headers.headers.addvaryheader=true"
-      - "traefik.http.middlewares.security-headers.headers.frameDeny=true"
-      - "traefik.http.middlewares.security-headers.headers.contentTypeNosniff=true"
+      
     cap_drop:
       - ALL
     command: [ "--config", "/app/config/config.json" ]

--- a/shimmer-hornet/docker-compose.yml
+++ b/shimmer-hornet/docker-compose.yml
@@ -33,12 +33,14 @@ services:
       - "traefik.http.services.hornet.loadbalancer.healthCheck.interval=15s"
       - "traefik.http.services.hornet.loadbalancer.healthCheck.timeout=5s"
 
-      - "traefik.http.routers.hornet.middlewares=redirect-dashboard"
+      - "traefik.http.routers.hornet.middlewares=security-headers,redirect-dashboard"
 
       # middlewares
       - "traefik.http.middlewares.redirect-dashboard.redirectregex.regex=^(https?://[^/]+)/?$$"
       - "traefik.http.middlewares.redirect-dashboard.redirectregex.replacement=$$1/dashboard/"
       - "traefik.http.middlewares.redirect-dashboard.redirectregex.permanent=true"
+      - "traefik.http.middlewares.security-headers.headers.frameDeny=true"
+      - "traefik.http.middlewares.security-headers.headers.contentTypeNosniff=true"
       
     cap_drop:
       - ALL

--- a/shimmer-hornet/docker-compose.yml
+++ b/shimmer-hornet/docker-compose.yml
@@ -33,19 +33,13 @@ services:
       - "traefik.http.services.hornet.loadbalancer.healthCheck.interval=15s"
       - "traefik.http.services.hornet.loadbalancer.healthCheck.timeout=5s"
 
-      - "traefik.http.routers.hornet.middlewares=security-headers,redirect-dashboard"
+      - "traefik.http.routers.hornet.middlewares=redirect-dashboard"
 
       # middlewares
       - "traefik.http.middlewares.redirect-dashboard.redirectregex.regex=^(https?://[^/]+)/?$$"
       - "traefik.http.middlewares.redirect-dashboard.redirectregex.replacement=$$1/dashboard/"
       - "traefik.http.middlewares.redirect-dashboard.redirectregex.permanent=true"
-
-      - "traefik.http.middlewares.security-headers.headers.accesscontrolallowmethods=GET,POST,PUT,DELETE,OPTIONS"
-      - "traefik.http.middlewares.security-headers.headers.customResponseHeaders.Access-Control-Allow-Origin=https://${HORNET_HOST:?WASP_HOST is missing}:${HORNET_HTTPS_PORT:-443}"
-      - "traefik.http.middlewares.security-headers.headers.accesscontrolmaxage=100"
-      - "traefik.http.middlewares.security-headers.headers.addvaryheader=true"
-      - "traefik.http.middlewares.security-headers.headers.frameDeny=true"
-      - "traefik.http.middlewares.security-headers.headers.contentTypeNosniff=true"
+      
     cap_drop:
       - ALL
     command: [ "--config", "/app/config/config.json" ]


### PR DESCRIPTION
Setting 
```
Access-Control-Allow-Origin=https://${HORNET_HOST:?WASP_HOST is missing}:${HORNET_HTTPS_PORT:-443}"
```

Only allows browser requests to the node originating from the same wasp and Hornet origin.
This restricts browser Dapplications from making requests to the Core  API of the node.
By [default](https://github.com/iotaledger/hornet/issues/1900#issuecomment-1671787597) Hornet allows it.
And I do not think you gain much security by restricting the origins when interacting with the node API.

This should fix #386.
